### PR TITLE
Add Kid Zone level

### DIFF
--- a/obstructio/README.md
+++ b/obstructio/README.md
@@ -3,7 +3,7 @@ Obstruct.io is a full-fledged JavaScript game complete with user editable levels
 
 [Click here to play the game](https://dmcheng2010.github.io/obstructio.html).
 
-Let me know if you beat all 16 levels! For an immersive experience, be sure to use headphones, particularly on the later levels...
+Let me know if you beat all 17 levels! For an immersive experience, be sure to use headphones, particularly on the later levels...
 
 ## Building Your Own Levels
 You can easily modify Obstructio.io to build your own custom levels:

--- a/obstructio/js/level_config.js
+++ b/obstructio/js/level_config.js
@@ -404,6 +404,18 @@ var hell = [
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ];
 
+var kidZone = [
+          "                      "
+          "                      "
+          "   o     o    o       "
+          "                      "
+          "  xxxxxxxxxxxxxxxxx   "
+          "  x     o        x    "
+          "  x 1            x    "
+          "  x        o     x    "
+          "  xxxxxxxxx!xxxxxx    "
+          "                      "
+        ];
 var MASTER_DICT = {
     "Unit Test World": [unitTest, {}, ""],
     "Easy": [easy, {}, "bach_gigue_english.mp3"],
@@ -421,7 +433,8 @@ var MASTER_DICT = {
     "Bunny World": [bunnyWorld, {}, "grieg_hallofthemountainking.mp3"],
     "Fool's Gold": [foolsGold, {}, "grieg_hallofthemountainking.mp3"], 
     "Into the Mines": [intoTheMines, {"=": 4}, "grieg_hallofthemountainking.mp3"],
-    "Hell": [hell, {"=": 4, "-": 5}, "stravinsky_riteofspring.mp3"]	
+    "Hell": [hell, {"=": 4, "-": 5}, "stravinsky_riteofspring.mp3"],	
+    "Kid Zone": [kidZone, {}, "bach_gigue_english.mp3"]
 };
 /*final ordering of levels*/
 var ALL_NAMES = [ 
@@ -430,7 +443,7 @@ var ALL_NAMES = [
         "Bomb Away",  "To the Sky", "Weeping Angel",
         "Ice World", "Elevator", 
         "Bunny World", "Fool's Gold", "Into the Mines",
-        "Hell"];
+        "Hell", "Kid Zone"];
         
 var ALL_PLANS = [];
 var ALL_SPEED_MULTIPLIERS = [];

--- a/summary.md
+++ b/summary.md
@@ -109,7 +109,7 @@ I strove towards clean code by:
 2. __Serialization__: I converted an object state into byte stream for transmission. This allows restarting at the last checkpoint.
 3. __Asynchronous Callbacks__: Callbacks enable interactivity in the game e.g. "When I click on this button, run this animation" 
 
-[Click here to see if you can beat all 16 levels in this very fun game.](https://danielmcheng1.github.io/obstructio/obstructio.html) Be sure to use your headphones!
+[Click here to see if you can beat all 17 levels in this very fun game.](https://danielmcheng1.github.io/obstructio/obstructio.html) Be sure to use your headphones!
 
 You can also easily modify Obstruct.io with your own custom levels. [Click here](https://github.com/danielmcheng1/danielmcheng1.github.io/blob/master/obstructio/README.md) to try building your own levels.
 


### PR DESCRIPTION
## Summary
- add a new `Kid Zone` level to the Obstruct.io game
- update level list and README to mention 17 levels

## Testing
- `git status --short`
