### PR TITLE
Improve Obstructio visuals

### DIFF
--- a/obstructio/css/game.css
+++ b/obstructio/css/game.css
@@ -13,7 +13,7 @@ relative position so that player can always be at the center
 .background  {
 	/*background: rgb(52, 166, 251);*/
 	/*background: rgb(116,204,244);*/
-	background: light blue;
+       background: #b0d8ff; /* light sky blue */
 	table-layout: fixed;
 	border-spacing: 0;
 }
@@ -27,7 +27,7 @@ relative position so that player can always be at the center
 	position: absolute; 
 }
 .player {
-	background: rgb(64, 64, 64);
+       background: #555555;
 }
 .lost .player {
 	background: rgb(160, 64, 64);
@@ -41,10 +41,10 @@ relative position so that player can always be at the center
 	background: white;
 }
 .lava {
-	background: rgb(255, 100, 100);
+       background: orangered;
 }
 .coin {
-	background: rgb(241, 229, 89); 
+       background: gold;
 }
 
 

--- a/obstructio/img/coin.svg
+++ b/obstructio/img/coin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+  <circle cx="10" cy="10" r="8" fill="gold" stroke="darkgoldenrod" stroke-width="2"/>
+</svg>

--- a/obstructio/img/lava.svg
+++ b/obstructio/img/lava.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+  <rect width="20" height="20" fill="orange"/>
+  <path d="M0 15 C5 10 15 20 20 15 V20 H0 Z" fill="red"/>
+</svg>

--- a/obstructio/js/run_level.js
+++ b/obstructio/js/run_level.js
@@ -1321,12 +1321,12 @@ cartesianBombSpraySprite.src = img_path + "cartesianBombSpray.png";
 cartesianBombSprite.src = img_path + "cartesianBomb.png";
 
 checkpointSprite.src = img_path + "checkpoint.png";
-coinSprite.src = img_path + "coin.png";
+coinSprite.src = img_path + "coin.svg";
 computerSprite.src = img_path + "computer.png";
 computerPausedSprite.src = img_path + "computerPaused.png";
 
 iceSprite.src = img_path + "ice.png";
-lavaSprite.src = img_path + "lava.png";
+lavaSprite.src = img_path + "lava.svg";
 
 playerCartesianBombPowerupSprite.src = img_path + "playerCartesianBombPowerup.png";
 playerLostSprite.src = img_path + "playerLost.png";
@@ -1435,7 +1435,7 @@ CanvasDisplay.prototype.clearDisplay = function() {
 	}
 	else {
 		//this.cx.fillStyle = "rgb(52, 166, 251)";
-		this.cx.fillStyle = "#add8e6";
+                this.cx.fillStyle = "#b0d8ff";
 	};
 	this.cx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 };


### PR DESCRIPTION
## Summary
- tweak color scheme for Obstructio
- switch coin and lava sprites to SVG graphics
- use new color for game canvas background

## Testing
- `true`